### PR TITLE
Add a few extra options, for varying density of lines

### DIFF
--- a/Leaflet.MetricGrid.js
+++ b/Leaflet.MetricGrid.js
@@ -31,6 +31,7 @@ L.MetricGrid = L.Layer.extend({
         weight: 2,                                           // use 2 for best results, else label rub-out is less good (antialiased pixels)
         color: "#00f",
         font: "bold 16px Verdana",
+        density: 1,
         minInterval: 100,                   // minimum grid interval in metres
         maxInterval: 100000,                // maximum grid interval in metres, the bounds values should be multiples of this
         minZoom: 4                          // minimum zoom at which grid is drawn
@@ -349,6 +350,9 @@ L.MetricGrid = L.Layer.extend({
             spacing = 100000;
         }
 
+        if (this.options.density)
+            spacing = spacing / this.options.density;
+         
         //limit to min/max interval
         if (spacing < this.options.minInterval) {
             spacing = this.options.minInterval;
@@ -474,8 +478,15 @@ L.MetricGrid = L.Layer.extend({
         var canvas = this._canvas;
         var map = this._map;
 
-        if (L.Browser.canvas && map && ((map.getZoom() >= this.options.minZoom))) {
-        
+        if (L.Browser.canvas && map) {
+            var zoom = map.getZoom();
+            if (this.options.minZoom && zoom < this.options.minZoom)
+                return;
+            if (this.options.maxZoom && zoom > this.options.maxZoom)
+                return;
+            if (this.options.skipZoom && this.options.skipZoom.indexOf(zoom) > -1)
+                return;
+
             var spacing = this._calcInterval();
             var proj = this.options.proj4ProjDef
             var ctx = canvas.getContext("2d");


### PR DESCRIPTION
Mainly to provide a 'extra dense' grid... 

        var gridOptions = {
                opacity: 0.3,
                weight: 0.7,
                showSquareLabels: [100000,10000,100]
        };
        var bGrid = L.britishGrid(gridOptions).addTo(map);

	gridOptions['weight'] = 0.4;
	gridOptions['showAxisLabels'] = [];
	gridOptions['showSquareLabels'] = [];
	gridOptions['density'] = 10; //draws gridlines at 10x density of normal.
	gridOptions['minZoom'] = 8; //below this will be very dense (could use skipZoom, but dont want any below 8 anyway)
	gridOptions['maxZoom'] = 16; //above this, minInterval means will be 100, same as main grid, so pointless rendering
	gridOptions['skipZoom'] = [10,13]; //at these two zoom levels the grid is too dense

        var bGrid2 = L.britishGrid(gridOptions).addTo(map);